### PR TITLE
Fix UTM zone construction for Southern Hemisphere and zones 1-9

### DIFF
--- a/skiba/buffer_and_sample.py
+++ b/skiba/buffer_and_sample.py
@@ -8,6 +8,8 @@ from pyproj import Transformer
 import os
 import numpy as np
 
+from skiba.common import to_utm_crs
+
 # ee.Authenticate()
 # ee.Initialize(project="ee-forestplotvariables")
 
@@ -168,7 +170,7 @@ class Buffer:
         radius_m = radius_feet * 0.3048
 
         # Project to local UTM for accurate distance calculations
-        utm_crs = f"EPSG:326{int((point.x + 180) // 6) + 1}"
+        utm_crs = to_utm_crs(point)
         transformer_to_utm = Transformer.from_crs(crs, utm_crs, always_xy=True)
         transformer_to_latlon = Transformer.from_crs(utm_crs, crs, always_xy=True)
         x, y = transformer_to_utm.transform(point.x, point.y)

--- a/skiba/buffer_coordinates.py
+++ b/skiba/buffer_coordinates.py
@@ -10,6 +10,8 @@ import json
 import os
 import numpy as np
 
+from skiba.common import to_utm_crs
+
 # ee.Authenticate()
 # ee.Initialize(project="ee-forestplotvariables")
 
@@ -153,7 +155,7 @@ class BufferCoordinates:
         radius_m = radius_feet * 0.3048
 
         # Project to local UTM for accurate distance calculations
-        utm_crs = f"EPSG:326{int((point.x + 180) // 6) + 1}"
+        utm_crs = to_utm_crs(point)
         transformer_to_utm = Transformer.from_crs(crs, utm_crs, always_xy=True)
         transformer_to_latlon = Transformer.from_crs(utm_crs, crs, always_xy=True)
         x, y = transformer_to_utm.transform(point.x, point.y)

--- a/skiba/common.py
+++ b/skiba/common.py
@@ -4,3 +4,32 @@
 def hello_world():
     """Prints "Hello World!" to the console."""
     print("Hello World!")
+
+
+def to_utm_crs(point):
+    """Return the EPSG code of the UTM zone that contains the given point.
+
+    Hemisphere-aware (326xx north, 327xx south) and zero-pads zones 1-9
+    so pyproj receives a valid 5-digit EPSG code.
+
+    Args:
+        point: A shapely Point in EPSG:4326 (lon=x, lat=y).
+
+    Returns:
+        str: EPSG code like ``"EPSG:32610"`` or ``"EPSG:32705"``.
+
+    Raises:
+        ValueError: If the point is outside the standard UTM latitude band
+            (|lat| > 84); UPS would be required there.
+    """
+    lon, lat = point.x, point.y
+    if lat > 84 or lat < -80:
+        raise ValueError(
+            f"Point at lat={lat} is outside the standard UTM band (-80, 84); "
+            "use UPS for polar regions."
+        )
+    zone = int((lon + 180) // 6) + 1
+    # Antimeridian edge case: lon == 180 yields zone 61; clamp to 60.
+    zone = min(zone, 60)
+    hemisphere_prefix = 326 if lat >= 0 else 327
+    return f"EPSG:{hemisphere_prefix}{zone:02d}"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,7 +6,9 @@ import unittest
 from unittest.mock import patch
 from io import StringIO
 
-from skiba.common import hello_world
+from shapely.geometry import Point
+
+from skiba.common import hello_world, to_utm_crs
 
 
 class TestCommon(unittest.TestCase):
@@ -23,6 +25,42 @@ class TestCommon(unittest.TestCase):
         with patch("sys.stdout", new=StringIO()):
             result = hello_world()
             self.assertIsNone(result)
+
+
+class TestToUtmCrs(unittest.TestCase):
+    """Tests for hemisphere-aware UTM zone construction (issue #87)."""
+
+    def test_northern_hemisphere_two_digit_zone(self):
+        # San Francisco, CA: zone 10N
+        self.assertEqual(to_utm_crs(Point(-122.4194, 37.7749)), "EPSG:32610")
+
+    def test_northern_hemisphere_single_digit_zone_is_zero_padded(self):
+        # lon=-153 → zone 5N (Aleutian Islands region).
+        # Previous buggy code produced "EPSG:3265" (wrong CRS entirely).
+        self.assertEqual(to_utm_crs(Point(-153.0, 57.0)), "EPSG:32605")
+
+    def test_southern_hemisphere_uses_327_prefix(self):
+        # Buenos Aires: zone 21S.
+        # Previous buggy code produced "EPSG:32621" (North zone) silently.
+        self.assertEqual(to_utm_crs(Point(-58.3816, -34.6037)), "EPSG:32721")
+
+    def test_southern_hemisphere_single_digit_zone(self):
+        # lon=-153 in the Southern Pacific → zone 5S.
+        self.assertEqual(to_utm_crs(Point(-153.0, -20.0)), "EPSG:32705")
+
+    def test_equator_treated_as_northern(self):
+        # lat == 0 uses the northern prefix by convention.
+        self.assertEqual(to_utm_crs(Point(0.0, 0.0)), "EPSG:32631")
+
+    def test_antimeridian_clamps_to_zone_60(self):
+        # lon == 180 would naively produce zone 61; must clamp to 60.
+        self.assertEqual(to_utm_crs(Point(180.0, 0.0)), "EPSG:32660")
+
+    def test_raises_outside_utm_band(self):
+        with self.assertRaises(ValueError):
+            to_utm_crs(Point(0.0, 85.0))
+        with self.assertRaises(ValueError):
+            to_utm_crs(Point(0.0, -85.0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fixes #87 — the UTM EPSG code was hard-coded to the `326` (North) prefix and wasn't zero-padded, so Southern Hemisphere points were silently projected into Northern zones and zones 1–9 produced wrong/invalid codes like `EPSG:3265`.
- Extract a hemisphere-aware `to_utm_crs(point)` helper in `skiba/common.py` (326xx / 327xx, zero-padded, antimeridian clamped, raises outside the standard UTM band) and call it from both `Buffer.create_obfuscated_points` and `BufferCoordinates.create_obfuscated_point`.
- Adds unit tests in `tests/test_common.py` covering N/S hemispheres, single- and two-digit zones, the equator, the antimeridian edge case, and polar raises.

## Test plan
- [x] `pytest tests/test_common.py` — 9 passed (7 new + 2 existing)
- [ ] Manual sanity check: run `Buffer` / `BufferCoordinates` on a Southern-Hemisphere sample CSV and confirm obfuscated points stay within the expected radius of the originals
- [ ] Manual sanity check: same for a point in UTM zone 5 (e.g. lon ≈ -153)

🤖 Generated with [Claude Code](https://claude.com/claude-code)