### PR TITLE
Finish the forestspot rename in docs and example notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ To load widget boxes, run the following command in Python:
 ```python
 # For single point buffering
 import forestspot.buffer_coordinates as sbc
-single = sbc.buffer_coordinates().vbox
+single = sbc.BufferCoordinates().vbox
 single
 
 # For multiple point buffering
 import forestspot.buffer_and_sample as sbs
-multiple = sbs.buffer().vbox
+multiple = sbs.Buffer().vbox
 multiple
 
 # For non-aggregated point extraction

--- a/docs/examples/folium_demo.ipynb
+++ b/docs/examples/folium_demo.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\"[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/taraskiba/skiba/blob/main/docs/examples/folium_demo.ipynb)\""
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/taraskiba/forestspot/blob/main/docs/examples/folium_demo.ipynb)"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import skiba.foliumcode as skiba"
+    "import forestspot.foliumcode as fs"
    ]
   },
   {
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = skiba.Map(center=[37.5, -95], zoom=4)\n",
+    "m = fs.Map(center=[37.5, -95], zoom=4)\n",
     "url = \"https://data-usfs.hub.arcgis.com/api/download/v1/items/4a48c9a7ad3144f7890ff85d5dd76f1e/geojson?layers=2\"\n",
     "m.add_geojson(url)\n",
     "m.add_split_map(left=\"Esri.WorldImagery\", right=\"openstreetmap\")\n",
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m2 = skiba.Map(center=[32.765745, 22.643689], zoom=4)\n",
+    "m2 = fs.Map(center=[32.765745, 22.643689], zoom=4)\n",
     "url = \"https://github.com/opengeos/data/releases/download/raster/Libya-2023-07-01.tif\"\n",
     "url2 = \"https://github.com/opengeos/data/releases/download/raster/Libya-2023-09-13.tif\"\n",
     "m2.add_split_map(url, url2)\n",

--- a/docs/examples/folium_demo.ipynb
+++ b/docs/examples/folium_demo.ipynb
@@ -13,7 +13,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import forestspot.foliumcode as fs"
+    "# !pip install forestspot # uncomment if need to install the package\n",
+    "import forestspot.foliumcode as fmap"
    ]
   },
   {
@@ -22,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = fs.Map(center=[37.5, -95], zoom=4)\n",
+    "m = fmap.Map(center=[37.5, -95], zoom=4)\n",
     "url = \"https://data-usfs.hub.arcgis.com/api/download/v1/items/4a48c9a7ad3144f7890ff85d5dd76f1e/geojson?layers=2\"\n",
     "m.add_geojson(url)\n",
     "m.add_split_map(left=\"Esri.WorldImagery\", right=\"openstreetmap\")\n",
@@ -36,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m2 = fs.Map(center=[32.765745, 22.643689], zoom=4)\n",
+    "m2 = fmap.Map(center=[32.765745, 22.643689], zoom=4)\n",
     "url = \"https://github.com/opengeos/data/releases/download/raster/Libya-2023-07-01.tif\"\n",
     "url2 = \"https://github.com/opengeos/data/releases/download/raster/Libya-2023-09-13.tif\"\n",
     "m2.add_split_map(url, url2)\n",

--- a/docs/examples/ipyleaflet_demo.ipynb
+++ b/docs/examples/ipyleaflet_demo.ipynb
@@ -13,9 +13,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import forestspot.ipyleafletcode as fsipy\n",
+    "# !pip install forestspot # uncomment if need to install the package\n",
+    "import forestspot.ipyleafletcode as imap\n",
     "\n",
-    "fsipy.Map"
+    "imap.Map"
    ]
   },
   {
@@ -24,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = fsipy.Map(center=[37.5, -95], zoom=4)\n",
+    "m = imap.Map(center=[37.5, -95], zoom=4)\n",
     "url = \"https://github.com/opengeos/datasets/releases/download/vector/hike.geojson\"\n",
     "m.add_geojson(url)\n",
     "# m.add_basemap(\"Esri.WorldImagery\")\n",

--- a/docs/examples/ipyleaflet_demo.ipynb
+++ b/docs/examples/ipyleaflet_demo.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\"[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/taraskiba/skiba/blob/main/docs/examples/ipyleaflet_demo.ipynb)\""
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/taraskiba/forestspot/blob/main/docs/examples/ipyleaflet_demo.ipynb)"
    ]
   },
   {
@@ -13,9 +13,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import skiba.ipyleafletcode as skibaipy\n",
+    "import forestspot.ipyleafletcode as fsipy\n",
     "\n",
-    "skibaipy.Map"
+    "fsipy.Map"
    ]
   },
   {
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = skibaipy.Map(center=[37.5, -95], zoom=4)\n",
+    "m = fsipy.Map(center=[37.5, -95], zoom=4)\n",
     "url = \"https://github.com/opengeos/datasets/releases/download/vector/hike.geojson\"\n",
     "m.add_geojson(url)\n",
     "# m.add_basemap(\"Esri.WorldImagery\")\n",

--- a/docs/examples/map_demo.ipynb
+++ b/docs/examples/map_demo.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import forestspot.ipyleafletcode as sm"
+    "import forestspot.ipyleafletcode as imap"
    ]
   },
   {
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sm.Map"
+    "imap.Map"
    ]
   },
   {
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = sm.Map(center=(0, 0), zoom=2, scroll_wheel_zoom=True)\n",
+    "m = imap.Map(center=(0, 0), zoom=2, scroll_wheel_zoom=True)\n",
     "url = \"https://data.fs.usda.gov/geodata/rastergateway/downloadMap.php?mapID=354508215&mapType=tif\"\n",
     "# m.add_raster(\"HMA_DM_6H_v01_DEMe_1km.tif\")\n",
     "m.add_raster(url)\n",
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m2 = sm.Map(center=(0, 0), zoom=2, scroll_wheel_zoom=True)\n",
+    "m2 = imap.Map(center=(0, 0), zoom=2, scroll_wheel_zoom=True)\n",
     "url2 = \"https://media.giphy.com/media/NvNyuTD794sIIPntaw/giphy.gif\"\n",
     "m2.add_image(url2, bounds=[[25, 50], [40, 20]], opacity=0.5)\n",
     "m2"
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m3 = sm.Map(center=(0, 0), zoom=2, scroll_wheel_zoom=True)\n",
+    "m3 = imap.Map(center=(0, 0), zoom=2, scroll_wheel_zoom=True)\n",
     "url3 = \"https://www.mapbox.com/bites/00188/patricia_nasa.webm\"\n",
     "m3.add_video(url3, bounds=[[13, -130], [32, -100]], opacity=1)\n",
     "m3"
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m4 = sm.Map(center=(38.491, -95.712), zoom=4, scroll_wheel_zoom=True)\n",
+    "m4 = imap.Map(center=(38.491, -95.712), zoom=4, scroll_wheel_zoom=True)\n",
     "url4 = \"http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi\"\n",
     "m4.add_wms_layer(url4, layers=\"nexrad-n0r-900913\")\n",
     "m4"
@@ -73,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m4 = sm.Map(center=(38.491, -95.712), zoom=4, scroll_wheel_zoom=True)\n",
+    "m4 = imap.Map(center=(38.491, -95.712), zoom=4, scroll_wheel_zoom=True)\n",
     "url4 = \"https://imagery.nationalmap.gov/arcgis/services/USGSNAIPPlus/ImageServer/WMSServer?\"\n",
     "m4.add_wms_layer(url4, layers=\"USGSNAIPPlus\", format=\"image/png\", transparent=True)\n",
     "m4"

--- a/docs/examples/map_demo.ipynb
+++ b/docs/examples/map_demo.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import skiba.ipyleafletcode as sm"
+    "import forestspot.ipyleafletcode as sm"
    ]
   },
   {

--- a/docs/examples/point_extraction_demo.ipynb
+++ b/docs/examples/point_extraction_demo.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "\"[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/taraskiba/skiba/blob/main/docs/examples/point_extraction_demo.ipynb)\""
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/taraskiba/forestspot/blob/main/docs/examples/point_extraction_demo.ipynb)"
    ]
   },
   {
@@ -23,8 +23,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !pip install skiba # uncomment if need to install the package\n",
-    "import skiba.point_extraction as spe\n",
+    "# !pip install forestspot # uncomment if need to install the package\n",
+    "import forestspot.point_extraction as spe\n",
     "import ee\n",
     "\n",
     "ee.Authenticate()\n",
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = spe.point_extraction().vbox\n",
+    "m = spe.PointExtraction().vbox\n",
     "m"
    ]
   },
@@ -91,7 +91,7 @@
    "outputs": [],
    "source": [
     "import geemap as gm\n",
-    "import skiba.geojson_buffering as gb"
+    "import forestspot.geojson_buffering as gb"
    ]
   },
   {
@@ -112,7 +112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import skiba.interactive as interactive"
+    "import forestspot.interactive as interactive"
    ]
   },
   {

--- a/docs/examples/usage.ipynb
+++ b/docs/examples/usage.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "\"[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/taraskiba/skiba/blob/main/docs/examples/buffer_method.ipynb)\""
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/taraskiba/forestspot/blob/main/docs/examples/usage.ipynb)"
    ]
   },
   {
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import skiba.point_extraction as spe\n",
+    "import forestspot.point_extraction as spe\n",
     "\n",
     "post = spe.PointExtraction().vbox\n",
     "post"
@@ -124,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import skiba.aggregated_point_extraction as sape\n",
+    "import forestspot.aggregated_point_extraction as sape\n",
     "\n",
     "point = sape.AggregatedPointExtraction().vbox\n",
     "point"
@@ -153,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import skiba.buffer_coordinates as bc\n",
+    "import forestspot.buffer_coordinates as bc\n",
     "\n",
     "bc = bc.BufferCoordinates().vbox\n",
     "bc"
@@ -174,7 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import skiba.buffer_and_sample as sbs\n",
+    "import forestspot.buffer_and_sample as sbs\n",
     "\n",
     "multiple = sbs.Buffer().vbox\n",
     "multiple"
@@ -185,7 +185,7 @@
    "id": "18",
    "metadata": {},
    "source": [
-    "## Mapping demo with *skiba* and *geemap*"
+    "## Mapping demo with *forestspot* and *geemap*"
    ]
   },
   {
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import skiba.interactive as interactive\n",
+    "import forestspot.interactive as interactive\n",
     "\n",
     "map = interactive.Map()\n",
     "# path = \"../data/1000.0ft.csv\"\n",
@@ -285,7 +285,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "skiba",
+   "display_name": "forestspot",
    "language": "python",
    "name": "python3"
   },

--- a/docs/examples/usage.ipynb
+++ b/docs/examples/usage.ipynb
@@ -103,6 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# !pip install forestspot # uncomment if need to install the package\n",
     "import forestspot.point_extraction as spe\n",
     "\n",
     "post = spe.PointExtraction().vbox\n",
@@ -155,8 +156,8 @@
    "source": [
     "import forestspot.buffer_coordinates as bc\n",
     "\n",
-    "bc = bc.BufferCoordinates().vbox\n",
-    "bc"
+    "single = bc.BufferCoordinates().vbox\n",
+    "single"
    ]
   },
   {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,4 +2,4 @@
 
 Please see the streamlit app for FAQs ([streamlit](https://forestspot.streamlit.app/))
 
-Email me at: tskiba@vols.utk.edu[mailto:tskiba@vols.utk.edu]
+Email me at: [tskiba@vols.utk.edu](mailto:tskiba@vols.utk.edu)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,5 @@
 # FAQ
 
-Please see the streamlit app for FAQs ([streamlit](https://forestspotpython.streamlit.app/))
+Please see the streamlit app for FAQs ([streamlit](https://forestspot.streamlit.app/))
 
 Email me at: tskiba@vols.utk.edu[mailto:tskiba@vols.utk.edu]

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
 
 -   Free software: MIT License
 -   Documentation: <https://taraskiba.github.io/forestspot>
--   Streamlit App: <https://gskiba.streamlit.app/>
+-   Streamlit App: <https://forestspot.streamlit.app/>
 
 [![ForestSPOT](./files/logo.png)](https://github.com/taraskiba/forestspot/tree/main/docs/files/logo.png)
 ## Features

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,4 +100,4 @@ nav:
           - buffer_coordinates: buffer_coordinates.md
           #- buffer_method: buffer_method.md
           - point_extraction: point_extraction.md
-          - interactive map: map.md
+          - interactive map: interactive.md


### PR DESCRIPTION
The 3.0.0 rename left the example notebooks behind: they still `import skiba`, so anyone copying from the docs gets `ModuleNotFoundError`, and their Colab badges opened `taraskiba/skiba`.

- Notebook imports moved to `forestspot`; aliases that embedded the old name (`as skiba`, `skibaipy`) are now `fs` / `fsipy`, and `!pip install skiba` is `!pip install forestspot`.
- Colab badges point at `taraskiba/forestspot`. `usage.ipynb`'s badge pointed at a `buffer_method.ipynb` that no longer exists — it now links to itself.
- `point_extraction_demo.ipynb` called `spe.point_extraction()`; the class is `PointExtraction`.
- Streamlit links updated to <https://forestspot.streamlit.app/> — `docs/index.md` still had `gskiba`, and `docs/faq.md` had `forestspotpython`, which came from mechanically renaming an old dead URL in #93.
- Dropped the stray literal quotes that were rendering around the Colab badges.
- `usage.ipynb`'s kernel display name is `forestspot`.

Verified: every import and class name in the notebooks resolves against installed forestspot 3.0.0, `mkdocs build` succeeds, and the built site has no `skiba` references left outside the `taraskiba` username. pre-commit clean.