### PR TITLE
Publish to PyPI with trusted publishing

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,5 +1,7 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflow uploads a Python package to PyPI when a release is created.
+# It authenticates with PyPI trusted publishing (OIDC), so no API token or
+# username/password secret is stored in this repository.
+# See https://docs.pypi.org/trusted-publishers/
 
 name: pypi
 
@@ -8,7 +10,7 @@ on:
         types: [created]
 
 jobs:
-    deploy:
+    build:
         runs-on: ubuntu-latest
 
         steps:
@@ -20,11 +22,32 @@ jobs:
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip
-                  pip install setuptools wheel twine build
-            - name: Build and publish
-              env:
-                  TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-                  TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-              run: |
-                  python -m build
-                  twine upload --skip-existing dist/*
+                  pip install build
+            - name: Build distributions
+              run: python -m build
+            - name: Upload distributions
+              uses: actions/upload-artifact@v4
+              with:
+                  name: dist
+                  path: dist/
+
+    publish:
+        needs: build
+        runs-on: ubuntu-latest
+        # Mandatory for trusted publishing: lets the job mint an OIDC token
+        # that identifies it to PyPI.
+        permissions:
+            id-token: write
+
+        steps:
+            - name: Download distributions
+              uses: actions/download-artifact@v4
+              with:
+                  name: dist
+                  path: dist/
+            - name: Publish to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                  # Keeps a re-run of a release from failing on files PyPI
+                  # already has, as the previous twine --skip-existing did.
+                  skip-existing: true

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,6 +1,6 @@
 # This workflow uploads a Python package to PyPI when a release is created.
-# It authenticates with PyPI trusted publishing (OIDC), so no API token or
-# username/password secret is stored in this repository.
+# It authenticates with PyPI trusted publishing (OIDC), so the workflow no
+# longer reads a stored PyPI username/password secret.
 # See https://docs.pypi.org/trusted-publishers/
 
 name: pypi
@@ -9,12 +9,19 @@ on:
     release:
         types: [created]
 
+# Build-time dependencies run in the build job; give them no more than read
+# access. The publish job re-grants itself the one permission it needs.
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest
 
         steps:
             - uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
             - name: Set up Python
               uses: actions/setup-python@v5
               with:
@@ -30,6 +37,10 @@ jobs:
               with:
                   name: dist
                   path: dist/
+                  # Fail here rather than in the publish job if the build
+                  # produced nothing, and allow re-running a failed release.
+                  if-no-files-found: error
+                  overwrite: true
 
     publish:
         needs: build
@@ -47,7 +58,3 @@ jobs:
                   path: dist/
             - name: Publish to PyPI
               uses: pypa/gh-action-pypi-publish@release/v1
-              with:
-                  # Keeps a re-run of a release from failing on files PyPI
-                  # already has, as the previous twine --skip-existing did.
-                  skip-existing: true


### PR DESCRIPTION
`pypi.yml` still uploads with twine using the `PYPI_USERNAME` / `PYPI_PASSWORD` secrets. This switches it to PyPI trusted publishing (OIDC via `pypa/gh-action-pypi-publish`), so no long-lived PyPI credential is needed to publish.

Build and publish are split into separate jobs, as PyPA recommends: `id-token: write` is scoped to the publish job, and the build job — the one that resolves and executes build dependencies — runs with `contents: read` and a checkout that doesn't persist credentials.

**Draft until the PyPI side is configured.** On <https://pypi.org/manage/project/forestspot/settings/publishing/>, add a GitHub publisher:

| field | value |
| --- | --- |
| owner | `taraskiba` |
| repository | `forestspot` |
| workflow | `pypi.yml` |
| environment | *(leave blank)* |

Once that's registered I'll mark this ready. Merging it before then would break the next release.

### Notes for review

- **No `skip-existing`.** The old workflow passed `twine --skip-existing`. Keeping it would let a re-release of an already-published version skip the upload and exit 0, so the Actions tab and the release page both go green while PyPI keeps serving the old files. PyPA advises against it for PyPI for exactly this reason; a duplicate upload now fails loudly.
- **Attestations.** `gh-action-pypi-publish` generates and uploads PEP 740 attestations by default for trusted-publishing projects, which `twine upload` never did. Left at the default (on) — worth knowing it's in the release path if a future upload fails verification.
- **No `environment:`.** PyPA's example gates publishing behind a GitHub environment with required reviewers. Creating one needs admin, which I don't have, so this is left off and the PyPI publisher must be registered with the environment field blank to match. Worth adding later, @taraskiba — it's a two-sided change (workflow *and* the PyPI publisher config) or the OIDC claim won't match.
- **After merge:** the `PYPI_USERNAME` / `PYPI_PASSWORD` secrets stay live and valid until they're deleted in repo settings. That needs your access, @taraskiba.

Verified: `python -m build` succeeds from a clean checkout and produces the sdist and wheel the publish job expects; actionlint and pre-commit clean.